### PR TITLE
Delegate Monitor links latest vote and new delegate transactions corrected.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ These programs and resources are required to install and run Shift Explorer
 Clone the Shift Explorer Repository:
 
 ```
-git clone https://github.com/shiftnrg/shift-explorer.git
+git clone https://github.com/ShiftProject/shift-explorer.git
 cd shift-explorer
 npm install
 ```

--- a/features/delegateMonitor.feature
+++ b/features/delegateMonitor.feature
@@ -102,7 +102,7 @@ Feature: Delegate Monitor
   Scenario: latest votes should link to transaction
     Given I'm on page "/delegateMonitor"
     When I click link on row no. 1 cell no. 2 of "votes" table
-    Then I should be on page "/tx/11267727202420741572"
+    Then I should be on page "/explorer/tx/11267727202420741572"
 
   Scenario: newest delegates should link to delegate
     Given I'm on page "/delegateMonitor"
@@ -112,7 +112,7 @@ Feature: Delegate Monitor
   Scenario: newest delegates should link to transaction
     Given I'm on page "/delegateMonitor"
     When I click link on row no. 1 cell no. 2 of "registrations" table
-    Then I should be on page "/tx/2535943083975103126"
+    Then I should be on page "/explorer/tx/2535943083975103126"
 
   Scenario: active delegates should link to delegate
     Given I'm on page "/delegateMonitor"

--- a/src/components/address/address.component.js
+++ b/src/components/address/address.component.js
@@ -11,6 +11,21 @@ const AddressConstructor = function ($rootScope, $stateParams, $location, $http,
 			},
 		}).then((resp) => {
 			if (resp.data.success) {
+				if (resp.data.locked_balance) {
+					resp.data.total_balance = parseFloat(resp.data.balance) + parseFloat(resp.data.locked_balance);
+				} else {
+					resp.data.total_balance = resp.data.balance;
+				}
+
+				if (resp.data.locked_bytes) {
+					resp.data.available_bytes = parseFloat(resp.data.locked_bytes);
+					if (resp.data.pinned_bytes) {
+						resp.data.available_bytes -= parseFloat(resp.data.pinned_bytes);
+					}
+				} else {
+					resp.data.available_bytes = 0;
+				}
+
 				vm.address = resp.data;
 			} else {
 				throw new Error('Account was not found!');

--- a/src/components/address/address.html
+++ b/src/components/address/address.html
@@ -54,9 +54,29 @@
 								<span class="btn-copy" clip-copy="vm.address.publicKey"></span>
 							</td>
 						</tr>
+						<tr data-ng-if="vm.address.locked_balance > 0">
+							<td><strong>Total Balance</strong></td>
+							<td class="text-right">{{vm.address.total_balance | currency:$root.currency:$root.decimalPlaces}} <span class="text-muted">{{$root.currency.symbol}}</span></td>
+						</tr>						
+						<tr data-ng-if="vm.address.locked_balance > 0">
+							<td><strong>Locked Balance</strong></td>
+							<td class="text-right">{{vm.address.locked_balance | currency:$root.currency:$root.decimalPlaces}} <span class="text-muted">{{$root.currency.symbol}}</span></td>
+						</tr>
 						<tr>
-							<td><strong>Total balance</strong></td>
+							<td><strong>Available Balance</strong></td>
 							<td class="text-right">{{vm.address.balance | currency:$root.currency:$root.decimalPlaces}} <span class="text-muted">{{$root.currency.symbol}}</span></td>
+						</tr>
+						<tr data-ng-if="vm.address.locked_bytes > 0">
+							<td><strong>Locked Bytes</strong></td>
+							<td class="text-right">{{vm.address.locked_bytes}} <span class="text-muted">Bytes</span></td>
+						</tr>												
+						<tr data-ng-if="vm.address.locked_bytes > 0">
+							<td><strong>Pinned Bytes</strong></td>
+							<td class="text-right">{{vm.address.pinned_bytes}} <span class="text-muted">Bytes</span></td>
+						</tr>
+						<tr data-ng-if="vm.address.locked_bytes > 0">
+							<td><strong>Available Bytes</strong></td>
+							<td class="text-right">{{vm.address.available_bytes}} <span class="text-muted">Bytes</span></td>
 						</tr>
 						<tr>
 							<td><strong>Transactions</strong></td>

--- a/src/components/transactions/transactions.html
+++ b/src/components/transactions/transactions.html
@@ -102,7 +102,6 @@
 			</div>
 		</div>
 	</div>
-
 	<div class="delegate" data-ng-if="vm.tx.votes.deleted">
 		<h2>Deleted votes <small>{{vm.tx.votes.deleted.length}}</small></h2>
 		<div class="row">
@@ -119,6 +118,47 @@
 			</div>
 		</div>
 	</div>
+
+	<div data-ng-if="vm.tx.asset.lock">
+		<h2>Locked Storage <small>{{vm.tx.asset.lock.length}}</small></h2>
+		<div class="table-responsive">
+			<table class="table summary">
+				<tbody>
+					<tr>
+						<td><strong>{{vm.tx.type == 8 ? "Locked" : "Unlocked"}} Size</strong></td>
+						<td class="text-right">{{vm.tx.asset.lock.bytes}} <span class="text-muted">Bytes</span></td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</div>
+
+	<div data-ng-if="vm.tx.asset.pin">
+		<h2>Pinned Data <small>{{vm.tx.asset.pin.length}}</small></h2>
+		<div class="table-responsive">
+			<table class="table summary">
+				<tbody>
+					<tr>
+						<td><strong>{{vm.tx.type == 10 ? "Pinned" : "Unpinned"}} Size</strong></td>
+						<td class="text-right">{{vm.tx.asset.pin.bytes}} <span class="text-muted">Bytes</span></td>
+					</tr>
+					<tr>
+						<td><strong>Data Hash</strong></td>
+						<td class="text-right">
+							<a href="https://storage-testnet.shiftproject.com/ipfs/{{vm.tx.asset.pin.hash}}" target="_blank">{{vm.tx.asset.pin.hash}}</a>
+						</td>
+					</tr>
+					<tr data-ng-if="vm.tx.asset.pin.parent">
+						<td><strong>Parent Transaction ID</strong></td>
+						<td class="text-right">
+							<a href="/tx/{{vm.tx.asset.pin.parent}}">{{vm.tx.asset.pin.parent}}</a>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</div>
+
 	<h2>Details</h2>
 	<div id="table-mobile" class="table-responsive">
 		<table class="table details">

--- a/src/services/tx-types.js
+++ b/src/services/tx-types.js
@@ -9,4 +9,8 @@ AppServices.value('txTypes', {
 	5: 'Dapp registration',
 	6: 'Dapp deposit',
 	7: 'Dapp withdrawal',
+	8: 'Lock storage',
+	9: 'Unlock storage',
+	10: 'Pin data',
+	11: 'Unpin data'
 });


### PR DESCRIPTION
### What was the problem?
When clicking on "Transaction" links of the delegate monitor under "Latest Votes" and "Newest Delegates" the link is missing the necessary "/explore/" addition to the URL. 
### How did I fix it?
Adding "/explorer" to "/tx/[transaction number]" to lines 105 and 115 of delegateMonitor.feature
### How to test it?
Install Shift Explorer and check the links function correctly
### Review checklist
- All new code follows best practices
